### PR TITLE
Bug-fix: Improved handling for ValueError raised by validate_api_record_keys

### DIFF
--- a/src/modules/orchestrator.py
+++ b/src/modules/orchestrator.py
@@ -32,11 +32,11 @@ class Orchestrator:
       """
       print("Enacting alphabetical scraping rule")    
       base_endpoint = ssm_value_dict["source_api_endpoint"]
-      # for i in alphabet:
-      print(f'Scraping records for {ssm_value_dict["source_api"]}')
-      print(f"Letter - a")
-      ssm_value_dict["source_api_endpoint"] = base_endpoint + api_mapping_manager.scraping_rule_dict["query"] + "a"
-      self.scrape_and_upload_records_to_dynamo_db(scraper, ssm_value_dict)
+      for i in alphabet:
+         print(f'Scraping records for {ssm_value_dict["source_api"]}')
+         print(f"Letter - {i}")
+         ssm_value_dict["source_api_endpoint"] = base_endpoint + api_mapping_manager.scraping_rule_dict["query"] + i
+         self.scrape_and_upload_records_to_dynamo_db(scraper, ssm_value_dict)
 
   def scrape_and_upload_records_to_dynamo_db(self, scraper, ssm_value_dict):
       try:

--- a/src/modules/orchestrator.py
+++ b/src/modules/orchestrator.py
@@ -32,11 +32,11 @@ class Orchestrator:
       """
       print("Enacting alphabetical scraping rule")    
       base_endpoint = ssm_value_dict["source_api_endpoint"]
-      for i in alphabet:
-        print(f'Scraping records for {ssm_value_dict["source_api"]}')
-        print(f"Letter - {i}")
-        ssm_value_dict["source_api_endpoint"] = base_endpoint + api_mapping_manager.scraping_rule_dict["query"] + i
-        self.scrape_and_upload_records_to_dynamo_db(scraper, ssm_value_dict)
+      # for i in alphabet:
+      print(f'Scraping records for {ssm_value_dict["source_api"]}')
+      print(f"Letter - a")
+      ssm_value_dict["source_api_endpoint"] = base_endpoint + api_mapping_manager.scraping_rule_dict["query"] + "a"
+      self.scrape_and_upload_records_to_dynamo_db(scraper, ssm_value_dict)
 
   def scrape_and_upload_records_to_dynamo_db(self, scraper, ssm_value_dict):
       try:
@@ -46,8 +46,12 @@ class Orchestrator:
         record_manager = RecordManager(api_records, ssm_value_dict)
         record_manager.execute()
       except ValueError as e:
-        message="No api_records have been found"
-        if str(e) == message:
-          print(message)
+        message_1="No api_records have been found"
+        message_2="There's a mismatch between api_record_keys and field_mapping_keys"
+        if str(e) == message_1:
+          print(message_1)
+        elif str(e) == message_2:
+          print(message_2)
+          raise e
       except Exception as e:
          raise e

--- a/src/modules/record_manager.py
+++ b/src/modules/record_manager.py
@@ -24,6 +24,7 @@ class RecordManager:
     print("Starting executing RecordManager")
     
     self.api_records = self.transform_data_for_upload(self.api_records)
+
     record_batches = self.get_record_batches(self.api_records, self.dynamo_db_batch_size)
     self.upload_batches_to_dynamo_db(record_batches)
     print("Finished executing RecordManager")

--- a/src/modules/utils/validator.py
+++ b/src/modules/utils/validator.py
@@ -68,13 +68,13 @@ def validate_api_records_exist(api_records, ssm_value_dict):
 def validate_api_record_keys(api_records, field_mapping):
   api_record_keys=set(list(api_records[0].keys()))
   field_mapping_keys=set(list(field_mapping.keys()))
-  try: 
-    if api_record_keys == field_mapping_keys:
-      return api_records
-  except KeyError as e:
-      extra_keys_in_field_mapping = field_mapping_keys - api_record_keys
-      extra_keys_in_api_mapping = api_record_keys - field_mapping_keys
-      raise Exception(f"Here's extra_keys_in_field_mapping: {extra_keys_in_field_mapping}. \n Here's extra_keys_in_api_mapping: {extra_keys_in_api_mapping} \n api_record_keys : {api_record_keys} \n field_mapping_keys : {field_mapping_keys}").with_traceback(e.__traceback__)
+  if api_record_keys == field_mapping_keys:
+    return api_records
+  else:
+    extra_keys_in_field_mapping = field_mapping_keys - api_record_keys
+    extra_keys_in_api_mapping = api_record_keys - field_mapping_keys
+    print(f"Here's extra_keys_in_field_mapping: {extra_keys_in_field_mapping}.\nHere's extra_keys_in_api_mapping: {extra_keys_in_api_mapping} \n api_record_keys : {api_record_keys} \nfield_mapping_keys : {field_mapping_keys}")
+    raise ValueError(f"There's a mismatch between api_record_keys and field_mapping_keys")
 
   
 

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -110,33 +110,22 @@ class TestUtils:
      with pytest.raises(ValueError):
         validate_api_records_exist([], target_api_1_ssm_value_dict)
 
-
-# def validate_api_records_exist(api_records, ssm_value_dict):
-#   message="No api_records have been found"
-#   if isinstance(api_records, dict):
-#     api_records=api_records[ssm_value_dict["source_api_records_key"]]
-#   if isinstance(api_records, list):
-#     length= len(api_records)
-#     if length > 0:
-#       return api_records
-#   elif api_records == None or length==0:
-#     raise ValueError(f"{message}")
-
-
   def test_validate_api_record_keys(self, target_api_1_records, target_api_1_field_mapping):
-     target_api_1_records[0].pop('nutritions')
-     
+     target_api_1_records[0].pop('nutritions')  
      assert validate_api_record_keys(target_api_1_records, target_api_1_field_mapping) == target_api_1_records
 
-  def test_validate_api_record_keys_raises_key_error_for_extra_key_in_field_mapping(self, target_api_1_records, target_api_1_field_mapping):
-     with pytest.raises(KeyError):
-        target_api_1_field_mapping["extra_field"] = 'x'
-        validate_api_record_keys(target_api_1_records[0], target_api_1_field_mapping)
+  def test_validate_api_record_keys(self, target_api_1_records, target_api_1_field_mapping):
+     target_api_1_records[0].pop('nutritions')  
+     assert validate_api_record_keys(target_api_1_records, target_api_1_field_mapping) == target_api_1_records
 
-  def test_validate_api_record_keys_raises_key_error_for_extra_key_in_api_records(self, target_api_1_records, target_api_1_records_with_dropped_fields_not_needed):
-     with pytest.raises(KeyError):
-        validate_api_record_keys(target_api_1_records[0], target_api_1_records_with_dropped_fields_not_needed)
+  def test_validate_api_record_keys_raises_value_error_for_extra_api_record_field(self, target_api_1_records, target_api_1_field_mapping):
+     target_api_1_records[0].pop('nutritions')
+     with pytest.raises(ValueError):
+         target_api_1_records[0]["extra_field"] = 'x'
+         validate_api_record_keys(target_api_1_records, target_api_1_field_mapping)
 
-
-
-     
+  def test_validate_api_record_keys_raises_value_error_for_extra_field_mapping_field(self, target_api_1_records, target_api_1_field_mapping):
+     target_api_1_records[0].pop('nutritions')
+     with pytest.raises(ValueError):
+         target_api_1_field_mapping["extra_field"] = 'x'
+         validate_api_record_keys(target_api_1_records, target_api_1_field_mapping)


### PR DESCRIPTION
An uncaught Exception for validate_api_record_keys, led to an uncaught type error exception in the RecordManager:

```
Unhandled exception.
[ERROR] TypeError: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/var/task/handler.py", line 12, in main
    orchestrator.execute()
  File "/var/task/modules/orchestrator.py", line 25, in execute
    self.scrape_and_upload_records_for_alphabetical_scraping_rule~(~scraper, ssm_value_dict, api_mapping_manager)
  File "/var/task/modules/orchestrator.py", line 39, in scrape_and_upload_records_for_alphabetical_scraping_rule
    self.scrape_and_upload_records_to_dynamo_db(scraper, ssm_value_dict)
  File "/var/task/modules/orchestrator.py", line 53, in scrape_and_upload_records_to_dynamo_db
    raise e
  File "/var/task/modules/orchestrator.py", line 47, in scrape_and_upload_records_to_dynamo_db
    record_manager.execute()
  File "/var/task/modules/record_manager.py", line 26, in execute
    self.api_records = self.transform_data_for_upload(self.api_records)
  File "/var/task/modules/record_manager.py", line 38, in transform_data_for_upload
    api_records = self.rename_fields(api_records, self.field_mapping)
  File "/var/task/modules/record_manager.py", line 63, in rename_fields
    for record in api_records:
```
This pr should fix this issue being encountered by the program. 